### PR TITLE
Add Kotlin README and mention example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Kotlin Example
+
+Repositori ini juga menyertakan contoh implementasi perhitungan skor TB menggunakan bahasa Kotlin pada direktori `kotlin/`. Baca `kotlin/README.md` untuk petunjuk kompilasi dan cara menjalankan contoh. Kode Kotlin ini juga dapat dilihat langsung di aplikasi melalui menu **Contoh Kotlin** pada halaman utama.

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -1,0 +1,17 @@
+# Kotlin TB Scoring Example
+
+File `TbScoring.kt` menunjukkan implementasi logika penilaian risiko TB dalam bahasa Kotlin.
+
+## Menjalankan Contoh
+
+1. Pastikan JDK dan Kotlin compiler (`kotlinc`) telah terpasang di komputer Anda.
+2. Kompilasi file menggunakan:
+   ```sh
+   kotlinc TbScoring.kt -include-runtime -d TbScoring.jar
+   ```
+3. Jalankan program contoh dengan:
+   ```sh
+   java -jar TbScoring.jar
+   ```
+
+Program contoh akan menghitung skor dari jawaban sampel dan menampilkan total skor beserta tingkat risikonya.

--- a/kotlin/TbScoring.kt
+++ b/kotlin/TbScoring.kt
@@ -1,0 +1,194 @@
+// Implementasi logika penilaian risiko TB versi Kotlin
+// Setiap bagian kode disertai penjelasan dalam bahasa Indonesia
+
+// Data class untuk opsi jawaban pada setiap pertanyaan
+data class Option(
+    val value: Int,     // nilai yang dipilih pengguna
+    val label: String,  // deskripsi pilihan
+    val points: Int     // poin yang diberikan pilihan ini
+)
+
+// Data class untuk pertanyaan di dalam kategori tertentu
+data class Question(
+    val id: String,            // id unik pertanyaan
+    val question: String,      // teks pertanyaan
+    val options: List<Option>  // daftar opsi yang tersedia
+)
+
+// Data class untuk kategori, mewadahi beberapa pertanyaan
+data class Category(
+    val name: String,                // nama kategori
+    val questions: List<Question>    // pertanyaan-pertanyaan di dalam kategori
+)
+
+// Enum untuk tingkatan risiko TB
+enum class RiskLevel { RENDAH, SEDANG, TINGGI }
+
+// Data class hasil perhitungan skor
+data class ScoreResult(
+    val totalScore: Int,  // jumlah skor yang diperoleh
+    val maxScore: Int,    // skor maksimum yang mungkin dicapai
+    val riskLevel: RiskLevel // tingkat risiko berdasarkan total skor
+)
+
+// Daftar kategori beserta pertanyaan dan opsi penilaiannya
+val assessmentCriteria: List<Category> = listOf(
+    Category(
+        "Riwayat dan Kontak",
+        listOf(
+            Question(
+                id = "exposure",
+                question = "Riwayat kontak/paparan dengan pasien TB?",
+                options = listOf(
+                    Option(0, "Tidak ada kontak/paparan", 0),
+                    Option(1, "Tidak jelas atau tidak diketahui", 1),
+                    Option(2, "Kontak dengan pasien TB BTA (-)", 2),
+                    Option(3, "Kontak dengan pasien TB BTA (+)", 3)
+                )
+            )
+        )
+    ),
+    Category(
+        "Uji Tuberkulin",
+        listOf(
+            Question(
+                id = "tuberculinTest",
+                question = "Hasil Uji Tuberkulin (Mantoux)?",
+                options = listOf(
+                    Option(0, "Negatif (<5mm)", 0),
+                    Option(1, "Meragukan (5-9mm)", 1),
+                    Option(2, "Positif (\u226510mm) atau reaksi vesikular", 3)
+                )
+            )
+        )
+    ),
+    Category(
+        "Status Gizi",
+        listOf(
+            Question(
+                id = "nutritionalStatus",
+                question = "Berat badan/keadaan gizi?",
+                options = listOf(
+                    Option(0, "Gizi baik (BB/TB > 90%)", 0),
+                    Option(1, "Gizi kurang (BB/TB 70-90%)", 1),
+                    Option(2, "Gizi buruk (BB/TB < 70%)", 3)
+                )
+            )
+        )
+    ),
+    Category(
+        "Gejala Klinis",
+        listOf(
+            Question(
+                id = "fever",
+                question = "Demam tanpa sebab jelas \u2265 2 minggu?",
+                options = listOf(
+                    Option(0, "Tidak ada", 0),
+                    Option(1, "Ada", 1)
+                )
+            ),
+            Question(
+                id = "cough",
+                question = "Batuk kronik \u2265 2 minggu?",
+                options = listOf(
+                    Option(0, "Tidak ada", 0),
+                    Option(1, "Ada", 1)
+                )
+            )
+        )
+    ),
+    Category(
+        "Pemeriksaan Fisik",
+        listOf(
+            Question(
+                id = "lymphNodes",
+                question = "Pembesaran kelenjar limfe (aksila, inguinal)?",
+                options = listOf(
+                    Option(0, "Tidak ada", 0),
+                    Option(1, "Ada, ukuran kecil (< 2cm)", 1),
+                    Option(2, "Ada, multipel atau besar (\u2265 2cm)", 3)
+                )
+            ),
+            Question(
+                id = "jointSwelling",
+                question = "Pembengkakan tulang/sendi (panggul, lutut, falang)?",
+                options = listOf(
+                    Option(0, "Tidak ada", 0),
+                    Option(1, "Ada", 3)
+                )
+            )
+        )
+    ),
+    Category(
+        "Pemeriksaan Penunjang",
+        listOf(
+            Question(
+                id = "chestXray",
+                question = "Foto toraks (rontgen dada)?",
+                options = listOf(
+                    Option(0, "Normal", 0),
+                    Option(1, "Gambaran TB tidak jelas", 1),
+                    Option(2, "Gambaran TB jelas", 3)
+                )
+            )
+        )
+    )
+)
+
+// Fungsi untuk menentukan tingkat risiko berdasarkan total skor
+fun interpretRisk(totalScore: Int): RiskLevel = when {
+    totalScore >= 6 -> RiskLevel.TINGGI   // skor 6 atau lebih = risiko tinggi
+    totalScore >= 4 -> RiskLevel.SEDANG   // skor 4-5 = risiko sedang
+    else -> RiskLevel.RENDAH              // skor di bawah 4 = risiko rendah
+}
+
+// Fungsi utama untuk menghitung skor dari jawaban yang diberikan
+fun calculateScore(answers: Map<String, Int>): ScoreResult {
+    var total = 0
+    var max = 0
+
+    // iterasi setiap kategori dan pertanyaannya
+    for (category in assessmentCriteria) {
+        for (q in category.questions) {
+            // cari jawaban yang sesuai untuk pertanyaan ini
+            val selectedValue = answers[q.id]
+            val selectedOption = q.options.find { it.value == selectedValue }
+
+            // tambahkan poin jawaban bila ada
+            if (selectedOption != null) {
+                total += selectedOption.points
+            }
+
+            // hitung poin maksimum dari setiap pertanyaan
+            max += q.options.maxOf { it.points }
+        }
+    }
+
+    // tentukan tingkat risiko berdasarkan total skor
+    val risk = interpretRisk(total)
+
+    // kembalikan hasil perhitungan
+    return ScoreResult(total, max, risk)
+}
+
+// Contoh penggunaan fungsi di atas
+fun main() {
+    // Map berisi pasangan id pertanyaan dan nilai yang dipilih pengguna
+    val sampleAnswers = mapOf(
+        "exposure" to 3,         // contoh kontak dengan BTA (+)
+        "tuberculinTest" to 2,   // hasil uji tuberkulin positif
+        "nutritionalStatus" to 1,
+        "fever" to 1,
+        "cough" to 1,
+        "lymphNodes" to 2,
+        "jointSwelling" to 0,
+        "chestXray" to 2
+    )
+
+    val result = calculateScore(sampleAnswers)
+
+    // Tampilkan hasil akhir ke konsol
+    println("Total Skor: ${result.totalScore} dari ${result.maxScore}")
+    println("Risiko TB: ${result.riskLevel}")
+}
+

--- a/src/components/KotlinExample.tsx
+++ b/src/components/KotlinExample.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, Code } from "lucide-react";
+import kotlinCode from '../../kotlin/TbScoring.kt?raw';
+
+const KotlinExample = ({ onBack }) => (
+  <div className="max-w-4xl mx-auto">
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="text-2xl flex items-center">
+              <Code className="h-6 w-6 mr-2 text-blue-600" />
+              Contoh Kotlin
+            </CardTitle>
+            <CardDescription>
+              Implementasi logika penilaian risiko TB versi Kotlin
+            </CardDescription>
+          </div>
+          <Button variant="outline" onClick={onBack}>
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Kembali
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <pre className="whitespace-pre overflow-auto text-sm bg-gray-900 text-gray-100 p-4 rounded-md">
+{kotlinCode}
+        </pre>
+        <div className="mt-4 text-sm">
+          <p className="mb-1 text-gray-600">Kompilasi dan jalankan:</p>
+          <pre className="bg-gray-100 p-2 rounded">
+kotlinc TbScoring.kt -include-runtime -d TbScoring.jar
+java -jar TbScoring.jar
+          </pre>
+        </div>
+      </CardContent>
+    </Card>
+  </div>
+);
+
+export default KotlinExample;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Stethoscope, FileText, BarChart3, History } from "lucide-react";
+import { Stethoscope, FileText, BarChart3, History, Code } from "lucide-react";
 import PatientForm from '@/components/PatientForm';
 import ScoringAssessment from '@/components/ScoringAssessment';
 import ResultsDashboard from '@/components/ResultsDashboard';
@@ -10,6 +10,7 @@ import ScoreHistory from '@/components/ScoreHistory';
 import GuidelinesPage from '@/components/GuidelinesPage';
 import BMICalculator from '@/components/BMICalculator';
 import LoginPage from '@/components/LoginPage';
+import KotlinExample from '@/components/KotlinExample';
 
 const Index = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -60,6 +61,8 @@ const Index = () => {
         return <GuidelinesPage onBack={() => setCurrentView('home')} />;
       case 'bmi-calculator':
         return <BMICalculator onBack={() => setCurrentView('home')} />;
+      case 'kotlin':
+        return <KotlinExample onBack={() => setCurrentView('home')} />;
       default:
         return (
           <div className="w-full px-4 space-y-6">
@@ -119,7 +122,7 @@ const Index = () => {
                 </CardContent>
               </Card>
 
-              <Card 
+              <Card
                 className="cursor-pointer hover:shadow-lg transition-shadow border-l-4 border-l-orange-500"
                 onClick={() => setCurrentView('bmi-calculator')}
               >
@@ -130,6 +133,21 @@ const Index = () => {
                 <CardContent className="py-2 px-2 sm:p-6">
                   <CardDescription className="text-center text-xs sm:text-sm">
                     Kalkulator BMI
+                  </CardDescription>
+                </CardContent>
+              </Card>
+
+              <Card
+                className="cursor-pointer hover:shadow-lg transition-shadow border-l-4 border-l-gray-500"
+                onClick={() => setCurrentView('kotlin')}
+              >
+                <CardHeader className="text-center py-3 px-2 sm:p-6">
+                  <Code className="h-6 w-6 sm:h-8 sm:w-8 text-gray-600 mx-auto mb-1 sm:mb-2" />
+                  <CardTitle className="text-sm sm:text-lg">Contoh Kotlin</CardTitle>
+                </CardHeader>
+                <CardContent className="py-2 px-2 sm:p-6">
+                  <CardDescription className="text-center text-xs sm:text-sm">
+                    Lihat kode TB scoring
                   </CardDescription>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Summary
- add README section for Kotlin usage
- provide Kotlin instructions in `kotlin/README.md`
- add web page to display Kotlin code example

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68565af219908322a7e2374bab60a3ee